### PR TITLE
Create devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/cpp:0-debian-11",
+  "features": {
+  }
+}


### PR DESCRIPTION
This adds a dev container configuration for Debian 11, which has a toolchain that builds ParallelMemoryBenchmark without problems.