### PR TITLE
Clone submodules in dev container after creation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/cpp:0-debian-11",
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
   "features": {
-  },
-  "postStartCommand": ["{ pwd; date; } | tee start.txt"]
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,5 @@
   "image": "mcr.microsoft.com/devcontainers/cpp:0-debian-11",
   "features": {
   },
-  "postStartCommand": ["git submodule update --init"]
+  "postStartCommand": ["{ pwd; date; } | tee start.txt"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,6 @@
   "image": "mcr.microsoft.com/devcontainers/cpp:0-debian-11",
   "features": {
   },
-  "postStartCommand": "git submodule update --init"
+  "postCreateCommand": "git submodule update --init",
+  "waitFor": "postCreateCommand"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,5 @@
   "image": "mcr.microsoft.com/devcontainers/cpp:0-debian-11",
   "features": {
   },
-  "postStartCommand": ["{ pwd; date; } | tee start.txt"]
+  "postCreateCommand": "git submodule update --init"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,5 @@
   "image": "mcr.microsoft.com/devcontainers/cpp:0-debian-11",
   "features": {
   },
-  "postCreateCommand": ["git submodule update --init"]
+  "postStartCommand": ["git submodule update --init"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
   "image": "mcr.microsoft.com/devcontainers/cpp:0-debian-11",
   "features": {
-  }
+  },
+  "postCreateCommand": ["git submodule update --init"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,5 @@
   "image": "mcr.microsoft.com/devcontainers/cpp:0-debian-11",
   "features": {
   },
-  "postCreateCommand": "git submodule update --init"
+  "postStartCommand": "git submodule update --init"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "image": "mcr.microsoft.com/devcontainers/cpp:0-debian-11",
   "features": {
-  }
+  },
+  "postStartCommand": ["{ pwd; date; } | tee start.txt"]
 }


### PR DESCRIPTION
So users don't have to do this manually.

If one attempts to configure or build without doing this first,
the error message is very unintuitive: cmake does not find ninja.