### PR TITLE
Build project in dev container onCreateCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,27 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/cpp:0-debian-11",
-  "features": {
-  },
-  "postCreateCommand": "git submodule update --init",
-  "waitFor": "postCreateCommand"
+    "image": "mcr.microsoft.com/devcontainers/cpp:0-debian-11",
+    "features": {
+        "ghcr.io/lukewiwa/features/shellcheck:0": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "bierner.markdown-preview-github-styles",
+                "eamodio.gitlens",
+                "GitHub.vscode-pull-request-github",
+                "mads-hartmann.bash-ide-vscode",
+                "mhutchie.git-graph",
+                "ms-vscode.cpptools-extension-pack",
+                "ms-vsliveshare.vsliveshare",
+                "stkb.rewrap",
+                "streetsidesoftware.code-spell-checker",
+                "timonwong.shellcheck"
+            ],
+            "settings": {
+                "gitlens.showWelcomeOnInstall": false,
+                "gitlens.showWhatsNewAfterUpgrades": false
+            }
+        }
+    },
+    "onCreateCommand": ".devcontainer/onCreate"
 }

--- a/.devcontainer/onCreate
+++ b/.devcontainer/onCreate
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+git submodule update --init
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -G Ninja ..
+ninja

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts need LF (Unix-style) line endings.
+/.devcontainer/onCreate text eol=lf

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,10 @@
+name: Run ShellCheck
+
+on: [push, pull_request]
+
+jobs:
+  shellcheck:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: 'actions/checkout@v3'
+      - uses: 'bewuethr/shellcheck-action@v2'


### PR DESCRIPTION
Among other benefits, this will facilitate prebuilds that are immediately ready to use. However, it does greatly increase the amount of time the container takes to create when not using prebuilds -- although, in many uses, one would then take that same amount of time, with greater annoyance, to manually trigger the build before doing much else.

The real reason to do this is to *configure* the project. Building causes that to happen, and is less confusing than only configuring (because one may wonder what was happening, if there is no usable binary). Configuring resolves, downloads, **and builds** vcpkg dependencies in the submodule, which is why it takes so long and is an area where prebuilds will be very helpful.